### PR TITLE
Extend readme based on the one of hyperspy-demos

### DIFF
--- a/.github/workflow/binder_on_pr.yml
+++ b/.github/workflow/binder_on_pr.yml
@@ -1,0 +1,28 @@
+# Reference https://mybinder.readthedocs.io/en/latest/howto/gh-actions-badges.html
+name: Binder Badge
+on: 
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  binder:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - name: comment on PR with Binder link
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          var PR_HEAD_USERREPO = process.env.PR_HEAD_USERREPO;
+          var PR_HEAD_REF = process.env.PR_HEAD_REF;
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_REF}) :point_left: Launch a binder notebook on branch _${PR_HEAD_USERREPO}/${PR_HEAD_REF}_`
+          })
+      env:
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR_HEAD_USERREPO: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+bin/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Rope
+.ropeproject
+
+# Django stuff:
+*.log
+*.pot
+
+# Sphinx documentation
+docs/_build/
+
+#Ipython checkpoints
+.ipynb_checkpoints
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,80 @@
-# lumispy-demos
-Demo files for the LumiSpy package
+# LumiSpy demos
+
+[![Live demos (Binder)](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/lumispy/lumispy-demos/master)
+[![Notebook Viewer (nbviewer)](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg?sanitize=true)](http://nbviewer.ipython.org/github/lumispy/lumispy-demos/tree/master/)
+
+## Introduction
+
+This repository contains [Jupyter Notebooks](http://jupyter.org/) to demonstrate and learn
+how to process multi-dimensional luminescence spectroscopy data with
+[LumiSpy](https://github.com/lumispy/lumispy). For learning purposes, refer also to the
+[HyperSpy User Guide](http://hyperspy.org/hyperspy-doc/current/index.html), as LumiSpy
+extends [HyperSpy](https://hyperspy.org) by signal types specifically for luminescence
+spectroscopy.
+
+
+## Visualising and running the demos.
+
+### (Interactive) Running the demos online
+
+[![Live demos (Binder)](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/lumispy/lumispy-demos/master)
+
+Follow [this link](https://mybinder.org/v2/gh/lumispy/lumispy-demos/master)
+or click the "launch binder" banner above to run the the demos on 
+[mybinder.org](https://mybinder.org/). The demos will run remotely, 
+and one can experiment with LumiSpy in a Jupyter notebook with no need 
+to install or configure any software locally.
+
+**Note:** depending on the remote server load, the interactive binder demo may 
+take up to several minutes to load. For a quicker (but non-interactive) 
+visualization, see below.
+
+### (Non-interactive) Visualizing the demos online
+
+[![Notebook Viewer (nbviewer)](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg?sanitize=true)](http://nbviewer.ipython.org/github/lumispy/lumispy-demos/tree/master/)
+
+Follow [this link](http://nbviewer.ipython.org/github/lumispy/lumispy-demos/tree/master/) 
+or click on the "render nbviewer" banner above
+to display the demos with the 
+[Jupyter Notebook viewer](http://nbviewer.jupyter.org). 
+[nbviewer](http://nbviewer.jupyter.org/) will allow you to view the notebooks online,
+but you will not be able to change them or evaluate any code, like is possible with the 
+[binder](https://mybinder.org/v2/gh/lumispy/lumispy-demos/master).
+
+### Running and visualizing the demos locally
+
+To run the demo notebooks locally, 
+clone or download the [demos repository](https://github.com/lumispy/lumispy-demos) 
+to your local machine, install LumiSpy with its dependencies and
+[Jupyter Lab](http://jupyterlab.readthedocs.io/en/latest/) or 
+[Jupyter Notebook](https://jupyter-notebook.readthedocs.io/en/stable/)
+and use either of the two to run the notebooks.
+
+
+#### (For developers) Testing the demos locally
+
+To test the demos, install
+[nbval](http://github.com/computationalmodelling/nbval) and
+[py.test](https://pytest.org/) and run
+
+```bash
+$ py.test
+```
+
+To help visualize differences/errors, install
+[nbdime](http://github.com/jupyter/nbdime) as well, and run the test with
+
+```bash
+$ py.test --nbdime
+```
+
+## Contributing
+
+To contribute new demos or improvements to the current ones fork the demos
+repository and send us a pull request. See the 
+[HyperSpy Developer Guide](http://hyperspy.org/hyperspy-doc/current/dev_guide.html) 
+for more details on how to contribute to the HyperSpy universe.
+
+For issues and discussions fill a [new issue](https://github.com/lumispy/lumispy-demos/issues) 
+in the lumispy-demos github repository.
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Live demos (Binder)](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/lumispy/lumispy-demos/master)
 [![Notebook Viewer (nbviewer)](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg?sanitize=true)](http://nbviewer.ipython.org/github/lumispy/lumispy-demos/tree/master/)
 
+<img src="https://github.com/LumiSpy/lumispy/blob/master/doc/media/logo_rec_april21.svg" width="300" alt="LumiSpy">
+
 ## Introduction
 
 This repository contains [Jupyter Notebooks](http://jupyter.org/) to demonstrate and learn

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+dependencies:
+  - lumispy
+  - hyperspy-base
+  - hyperspy-gui-ipywidgets
+  - ipympl

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --nbval-lax --current-env
+usefixtures = tmpdir


### PR DESCRIPTION
Extend readme for lumispy-demos based on the one of hyperspy-demos, especially linking to `binder` and `nbviewer`.
Create environment.yml for binder to work.
Add pytest.ini to allow testing.
Add the logo to the readme.
Comment on PRs with binder link to allow for easier review (see https://mybinder.readthedocs.io/en/latest/howto/gh-actions-badges.html)

Closes #4.