### PR TITLE
Update HyperSpy2.0 compatibility comments

### DIFF
--- a/Workshops/230324_CLEBIC_HyperSpy-LumiSpy.ipynb
+++ b/Workshops/230324_CLEBIC_HyperSpy-LumiSpy.ipynb
@@ -583,6 +583,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -665,6 +666,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -1079,7 +1081,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can **add markers** for the *FWHM interval* and the *centre of mass* to the signal object and plot them on the spectra:"
+    "Now we can **add markers** for the *FWHM interval* and the *centre of mass* to the signal object and plot them on the spectra:\n",
+    "\n",
+    "*Note that all markers will be renamed in HyperSpy 2.0, `vertical_line` will be replaced by `VerticalLines`*"
    ]
   },
   {
@@ -1228,7 +1232,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/Workshops/230704_Sfmu_LumiSpy.ipynb
+++ b/Workshops/230704_Sfmu_LumiSpy.ipynb
@@ -476,7 +476,7 @@
    "source": [
     "Now we can **add markers** for the *FWHM interval* (grey) and the *centre of mass* (black) to the signal object and plot them on the spectra.\n",
     "\n",
-    "*Note that all markers will be renamed in HyperSpy 2.0, `vertical_line` will be replaced by `VerticalLine`*"
+    "*Note that all markers will be renamed in HyperSpy 2.0, `vertical_line` will be replaced by `VerticalLines`*"
    ]
   },
   {
@@ -777,7 +777,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
`vertical_line` has been replaced by `VerticalLines` in HyperSpy 2.0
Everything else in the notebooks should still be running correctly